### PR TITLE
Refactor size standard validation and rescaling

### DIFF
--- a/DNAnet/data/data_models/hid_image.py
+++ b/DNAnet/data/data_models/hid_image.py
@@ -20,6 +20,8 @@ from DNAnet.data.utils import (
     find_peak_idx_near_or_in_range,
     get_interpolated_basepairs,
     rescale_dye,
+    BASE_PAIR_START,
+    BASE_PAIR_END,
 )
 from DNAnet.typing import PathLike
 from DNAnet.utils import load_donor_alleles_provedit, load_donor_alleles
@@ -107,21 +109,28 @@ class HIDImage(Image):
             return None
         # Use the size standard to translate the location in the profile (array) to base pairs
         interpolated_base_pairs = get_interpolated_basepairs(np.array(profile[-1]), self.size_standard)
-        # using none checks is defnitely not the best way to validate the size standard,
         if interpolated_base_pairs is None:
             # If the size standard does not pass validation, interpolated_base_pairs
             # becomes None and the image will be skipped when creating a dataset
             return None
-        
+
+        # Determine indices that map the profile to a common base pair range
+        rescaled_indices = rescale_dye(
+            interpolated_base_pairs,
+            self.size_standard,
+            target_range=(BASE_PAIR_START, BASE_PAIR_END),
+        )
+
         # Scale the profile using the size standard
-        data = self._rescale_profile(profile,
-                                     interpolated_base_pairs,
-                                     self.size_standard,
-                                     self.include_size_standard)
-        
+        data = self._rescale_profile(
+            profile,
+            rescaled_indices,
+            self.include_size_standard,
+        )
+
         # Create a scaler, which is used to map a pixel index in the profile to a base pair
         # location, i.e. the first pixel is in fact BASE_PAIR_START, the last pixel is BASE_PAIR_END
-        self._scaler = interpolated_base_pairs[rescale_dye(interpolated_base_pairs, self.size_standard)]
+        self._scaler = interpolated_base_pairs[rescaled_indices]
 
         called_alleles = None
         # Determine the called alleles from the annotations file 
@@ -194,22 +203,23 @@ class HIDImage(Image):
         return self._scaler[np.newaxis, :]
 
     @staticmethod
-    def _rescale_profile(profile: np.ndarray,
-                         interpolated_base_pairs: np.ndarray,
-                         size_standard: str,
-                         include_standard: bool) -> np.ndarray:
-        """
-        Rescale profile based on interpolated base pairs.
+    def _rescale_profile(
+        profile: np.ndarray,
+        rescale_indices: np.ndarray,
+        include_standard: bool,
+    ) -> np.ndarray:
+        """Rescale profile based on precomputed rescale indices.
 
         :param profile: array of dyes in chronological order
-        :param interpolated_base_pairs: the interpolated base pairs
-        :param include_standard: if the size standard should be included
-            in the final profile/data
+        :param rescale_indices: indices of the original profile corresponding to
+            each pixel in the rescaled profile
+        :param include_standard: if the size standard should be included in the
+            final profile/data
         :return: parsed profile as array
         """
         # Select profile based on include_standard flag
         selected_profile = profile if include_standard else profile[:-1]
-        data = selected_profile[:, rescale_dye(interpolated_base_pairs, size_standard)]
+        data = selected_profile[:, rescale_indices]
         return data[..., np.newaxis]
 
     def _get_segmentation(self,

--- a/DNAnet/data/data_models/synthetic_image.py
+++ b/DNAnet/data/data_models/synthetic_image.py
@@ -9,7 +9,14 @@ from DNAnet.data.data_models import Annotation, Panel
 from DNAnet.data.data_models.base import Image
 from DNAnet.data.data_models.hid_image import HIDImage
 from DNAnet.data.kit_compatibility.lane_standards import InternalSizeStandard
-from DNAnet.data.utils import find_peak_boundary, find_peak_idx_near_or_in_range, get_interpolated_basepairs, rescale_dye
+from DNAnet.data.utils import (
+    find_peak_boundary,
+    find_peak_idx_near_or_in_range,
+    get_interpolated_basepairs,
+    rescale_dye,
+    BASE_PAIR_START,
+    BASE_PAIR_END,
+)
 from DNAnet.data.parsing import parse_called_alleles
 from DNAnet.utils import load_donor_alleles, load_donor_alleles_provedit, load_donor_alleles_synthetic_data
 from DNAnet.typing import PathLike
@@ -80,15 +87,23 @@ class SyntheticImage(Image):
         interpolated_base_pairs = get_interpolated_basepairs(np.array(profile[-1]), self.size_standard)
         if interpolated_base_pairs is None:
             raise ValueError(f"Invalid size standard for file {self.path}")
+
+        rescaled_indices = rescale_dye(
+            interpolated_base_pairs,
+            self.size_standard,
+            target_range=(BASE_PAIR_START, BASE_PAIR_END),
+        )
+
         # Scale the profile using the size standard
-        data = self._rescale_profile(profile,
-                                     interpolated_base_pairs,
-                                     self.size_standard,
-                                     self.include_size_standard)
-        
+        data = self._rescale_profile(
+            profile,
+            rescaled_indices,
+            self.include_size_standard,
+        )
+
         # Create a scaler, which is used to map a pixel index in the profile to a base pair
         # location, i.e. the first pixel is in fact BASE_PAIR_START, the last pixel is BASE_PAIR_END
-        self._scaler = interpolated_base_pairs[rescale_dye(interpolated_base_pairs, self.size_standard)]
+        self._scaler = interpolated_base_pairs[rescaled_indices]
 
         # called_alleles = None
         # # Determine the called alleles from the annotations file 
@@ -119,12 +134,13 @@ class SyntheticImage(Image):
 
 
     @staticmethod
-    def _rescale_profile(profile: np.ndarray,
-                         interpolated_base_pairs: np.ndarray,
-                         size_standard: str,
-                         include_standard: bool) -> np.ndarray:
+    def _rescale_profile(
+        profile: np.ndarray,
+        rescale_indices: np.ndarray,
+        include_standard: bool,
+    ) -> np.ndarray:
         selected_profile = profile if include_standard else profile[:-1]
-        data = selected_profile[:, rescale_dye(interpolated_base_pairs, size_standard)]
+        data = selected_profile[:, rescale_indices]
         return data[..., np.newaxis]
     
     

--- a/DNAnet/data/utils.py
+++ b/DNAnet/data/utils.py
@@ -10,14 +10,8 @@ import scipy
 
 LOGGER = logging.getLogger('dnanet')
 
-
-# --- BEGIN MOD: Amar (2025-04-19) ---
-# This is the begin and end number of base pairs for the ILS.
-# Instead of hardcoding, we can use the values from lane_standard.py.
-
-# BASE_PAIR_START, BASE_PAIR_END = 65, 475
-# RESCALE_SIZE = 4096
-# --- END MOD: Amar (2025-04-19) ---
+# Range to which all profiles are scaled in base pairs
+BASE_PAIR_START, BASE_PAIR_END = 60, 480
 
 
 def assert_image_data_valid_format(data: np.ndarray,
@@ -68,61 +62,35 @@ def process_image(
 def validate_ss_peaks(
     peaks: np.ndarray,
     expected_bps: np.ndarray,
-    min_pixels_per_bp: float = 7,
-    max_pixels_per_bp: float = 13
+    max_deviation: float = 5.0,
+    poly_degree: int = 2,
 ) -> bool:
-    """
-    Validate whether the identified peaks in the size standard are likely to
-    correspond with at least one of the provided base pair arrays.
-    Since we look at distances between peaks, is that why peaks will need to be one element shorter than the base pair array?
+    """Validate that detected size-standard peaks map to expected base-pair values.
 
-    In this method we conduct up to 3 checks:
-    1. Check if the relative distances between the peaks are within the expected range of base pairs.
-    2. If the first check fails, we check if the relative distances of the last 20 peaks are within the expected range.
-    3. If the first two checks fail, we check if the relative distances of the peaks after a certain threshold (e.g., 4000) are within the expected range.
+    A polynomial of ``poly_degree`` (quadratic by default) is fitted to translate
+    peak indices to base pairs. If the maximum absolute deviation between the
+    fitted values and ``expected_bps`` is below ``max_deviation`` the peaks are
+    considered valid.
 
-    :param size_standard_peaks_idxs: Indices of detected peaks in the size standard channel.
-    :param expected_bps: Array or list of arrays of expected base pair positions for dye standards.
-    :param min_pixels_per_bp: Minimum allowed pixels per base pair.
-    :param max_pixels_per_bp: Maximum allowed pixels per base pair.
-    :return: True if any check is passed, False otherwise.
+    :param peaks: indices of detected peaks in the size standard channel.
+    :param expected_bps: expected base-pair positions for the peaks.
+    :param max_deviation: maximum allowed deviation in base pairs.
+    :param poly_degree: degree of the polynomial used for fitting.
+    :return: ``True`` when the peaks pass validation, ``False`` otherwise.
     """
 
-    distances_between_peaks = np.abs(
-        np.diff((peaks,
-                    scipy.ndimage.shift(peaks, shift=1, mode='nearest')
-                    ), axis=0))[0, 1:]
-    
-    distance_basepairs = np.abs(
-        np.diff((expected_bps,
-                    scipy.ndimage.shift(expected_bps, shift=1, mode='nearest')
-                    ), axis=0))[0, 1:]
-    
-    relative_distances = distances_between_peaks / distance_basepairs
+    if len(peaks) != len(expected_bps):
+        return False
+    if np.any(np.diff(peaks) <= 0):
+        return False
 
-    passes_validation = bool(np.all((relative_distances <= max_pixels_per_bp) & (relative_distances >= min_pixels_per_bp)))
-    if passes_validation:
-        return True
-    # LOGGER.warning("Size standard peaks validation failed. Trying validation only scan points after 4000")
-    
-    # Temporary fix: only look at last 20 peaks
-    # since first few peaks are often not ILS peaks, but primer flares.
-    # TODO: Detect if peaks are primer flares and remove them. This would be in previous step.
-    passes_validation = passes_validation or bool(np.all((relative_distances[-20:] <= max_pixels_per_bp) & (relative_distances[-20:] >= min_pixels_per_bp)))
-    
-    # Adjustable, but we can expect in most EPGs that the first 4000 scan points do not contain any alleles.
-    threshold = 3700
-    peaks_filtered = peaks[peaks >= threshold]
-    distances_between_peaks_filtered = np.abs(
-        np.diff((peaks_filtered,
-                    scipy.ndimage.shift(peaks_filtered, shift=1, mode='nearest')
-                    ), axis=0))[0, 1:]
+    try:
+        coeffs = np.polyfit(peaks, expected_bps, poly_degree)
+    except Exception:
+        return False
 
-
-    relative_distances_filtered = relative_distances[-distances_between_peaks_filtered.shape[0]:]
-
-    return passes_validation or bool(np.all((relative_distances_filtered <= max_pixels_per_bp) & (relative_distances_filtered >= min_pixels_per_bp)))
-
+    fitted = np.polyval(coeffs, peaks)
+    return bool(np.max(np.abs(fitted - expected_bps)) <= max_deviation)
 
 
 def get_interpolated_basepairs(size_standard_dye_lane: np.ndarray, size_standard: str) -> (
@@ -148,9 +116,14 @@ def get_interpolated_basepairs(size_standard_dye_lane: np.ndarray, size_standard
     if not validate_ss_peaks(relevant_peak_indices_from_lane_standard, expected_bps=bps):
         return None
 
-    # returns an interpolator function that maps the indices of the size standard peaks (i.e. scan points) to the base pairs
-    interpolator = basepair_interpolator(indices=relevant_peak_indices_from_lane_standard,
-                                   original_x_values=bps)
+    # returns an interpolator function that maps the indices of the size standard
+    # peaks (i.e. scan points) to the base pairs. We enable extrapolation so that
+    # rescaling beyond the observed range (e.g. to 60-480 bp) remains possible.
+    interpolator = basepair_interpolator(
+        indices=relevant_peak_indices_from_lane_standard,
+        original_x_values=bps,
+        extrapolate=True,
+    )
     
     # interpolate these to the complete array (all values for indices outside
     # the size_standard_peaks_idxs range will be 0)
@@ -281,17 +254,24 @@ def basepair_interpolator(indices: np.ndarray,
     return interp
 
 
-def rescale_dye(basepairs: np.ndarray, size_standard: str, rescale_size: int = 4096) -> np.ndarray:
-    """
-    Rescale the interpolated base pairs of the size standard so that they fit between
-    BASE_PAIR_START and BASE_PAIR_END, on exactly RESCALE_SIZE pixels. The output array
-    should function as a translator that indicates which pixel indices (of an unscaled dye) should
-    be on every pixel location.
-    E.g. if the output is np.array([3825, 3826, ..]), then a pixel on index 3825 should be
-    scaled to the first pixel, and a pixel on index 3826 should be scaled to the second pixel.
+def rescale_dye(
+    basepairs: np.ndarray,
+    size_standard: str,
+    rescale_size: int = 4096,
+    target_range: Optional[Tuple[int, int]] = None,
+) -> np.ndarray:
+    """Map base-pair positions to scaled pixel indices.
+
+    ``basepairs`` is an array containing the interpolated base-pair value for
+    each scan point of the electropherogram. ``target_range`` defines the base
+    pair range of the rescaled profile (defaults to the size standard range when
+    ``None``).
     """
     bps = get_size_standard_bps(size_standard)
-    bp_start, bp_end = bps[0], bps[-1]
+    if target_range is None:
+        bp_start, bp_end = bps[0], bps[-1]
+    else:
+        bp_start, bp_end = target_range
     target_linspace = np.linspace(bp_start, bp_end, rescale_size)
 
     # Presorting interpolated base pairs

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -10,6 +10,8 @@ from DNAnet.data.utils import (
     find_peak_idx_near_or_in_range,
     find_peak_near_idx,
     find_peaks_above_threshold,
+    validate_ss_peaks,
+    rescale_dye,
 )
 
 
@@ -108,3 +110,21 @@ def test_interpolate_basepairs_float():
     # Extrapolation
     interp = basepair_interpolator(indices, original_x_values, extrapolate=True)
     assert_array_equal(interp(93.47), np.array([93.29]))
+
+
+def test_validate_ss_peaks_quadratic():
+    bps = np.array([60, 80, 100, 120, 140])
+    peaks = 10 * bps + 0.05 * (bps - 60) ** 2
+    assert validate_ss_peaks(peaks, bps)
+    bad_peaks = peaks.copy()
+    bad_peaks[-1] += 500
+    assert not validate_ss_peaks(bad_peaks, bps)
+
+
+def test_rescale_dye_target_range():
+    basepairs = np.linspace(50, 500, 10000)
+    idx = rescale_dye(basepairs, "WEN_ILS", rescale_size=5, target_range=(60, 480))
+    scaled = basepairs[idx]
+    assert scaled[0] == pytest.approx(60, abs=1)
+    assert scaled[-1] == pytest.approx(480, abs=1)
+    assert len(idx) == 5


### PR DESCRIPTION
## Summary
- use quadratic fitting to validate size standard peaks
- rescale profiles to a common 60-480 bp range
- add tests for new validation and rescaling utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6899cc95384883269e44c256bcb8212b